### PR TITLE
[0.11.x] Update compatibility for draw-steel 0.11.x and Foundry 13.351

### DIFF
--- a/module.json
+++ b/module.json
@@ -4,7 +4,7 @@
   "description": "A party-level project board for tracking downtime project progress, career project points, and point sources in the Draw Steel system for Foundry VTT.",
   "url": "https://github.com/bruceamoser/draw-steel-downtime-project-tracker",
   "bugs": "https://github.com/bruceamoser/draw-steel-downtime-project-tracker/issues",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "license": "LICENSE.md",
   "authors": [
     {
@@ -14,14 +14,17 @@
   ],
   "compatibility": {
     "minimum": "13",
-    "verified": "13"
+    "verified": "13.351"
   },
   "relationships": {
     "systems": [
       {
         "id": "draw-steel",
         "type": "system",
-        "compatibility": {}
+        "compatibility": {
+          "minimum": "0.9.0",
+          "verified": "0.11.1"
+        }
       }
     ]
   },
@@ -40,5 +43,5 @@
     }
   ],
   "manifest": "https://github.com/bruceamoser/draw-steel-downtime-project-tracker/releases/latest/download/module.json",
-  "download": "https://github.com/bruceamoser/draw-steel-downtime-project-tracker/releases/download/v0.3.1/ds-project-tracker-v0.3.1.zip"
+  "download": "https://github.com/bruceamoser/draw-steel-downtime-project-tracker/releases/download/v0.3.2/ds-project-tracker-v0.3.2.zip"
 }


### PR DESCRIPTION
## Summary

Updates compatibility declarations for draw-steel 0.11.x support.

## Changes

- Bumped Foundry erified from 13 to 13.351`n- Added draw-steel system compatibility: minimum  .9.0, verified  .11.1`n- Bumped module version to  .3.2`n
Closes #2
